### PR TITLE
add scarlet lifecycle hook

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation 'com.tinder.scarlet:stream-adapter-coroutines:0.1.12'
     implementation 'com.tinder.scarlet:stream-adapter-rxjava2:0.1.12'
     implementation 'com.tinder.scarlet:websocket-okhttp:0.1.12'
+    implementation 'com.tinder.scarlet:lifecycle-android:0.1.12'
 
     implementation "com.google.dagger:hilt-android:2.44"
     implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'

--- a/app/src/main/kotlin/social/plasma/di/NetworkModule.kt
+++ b/app/src/main/kotlin/social/plasma/di/NetworkModule.kt
@@ -1,8 +1,10 @@
 package social.plasma.di
 
+import android.app.Application
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.tinder.scarlet.Scarlet
+import com.tinder.scarlet.lifecycle.android.AndroidLifecycle
 import com.tinder.scarlet.messageadapter.moshi.MoshiMessageAdapter
 import com.tinder.scarlet.streamadapter.rxjava2.RxJava2StreamAdapterFactory
 import com.tinder.streamadapter.coroutines.CoroutinesStreamAdapterFactory
@@ -34,8 +36,10 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun providesScarletBuilder(moshi: Moshi): Scarlet.Builder = Scarlet.Builder()
-        .addMessageAdapterFactory(MoshiMessageAdapter.Factory(moshi))
-        .addStreamAdapterFactory(RxJava2StreamAdapterFactory())
-        .addStreamAdapterFactory(CoroutinesStreamAdapterFactory())
+    fun providesScarletBuilder(application: Application, moshi: Moshi): Scarlet.Builder =
+        Scarlet.Builder()
+            .addMessageAdapterFactory(MoshiMessageAdapter.Factory(moshi))
+            .addStreamAdapterFactory(RxJava2StreamAdapterFactory())
+            .addStreamAdapterFactory(CoroutinesStreamAdapterFactory())
+            .lifecycle(AndroidLifecycle.ofApplicationForeground(application))
 }


### PR DESCRIPTION
Adds app lifecycle observer to scarlet so it can automatically pause websocket connections when the app goes to the background.
It also resumes the connection once the app returns to the foreground
