### PR TITLE
Make filters nullable instead of empty sets

### DIFF
--- a/nostr/src/main/kotlin/social/plasma/nostr/relay/RelayImpl.kt
+++ b/nostr/src/main/kotlin/social/plasma/nostr/relay/RelayImpl.kt
@@ -24,6 +24,7 @@ class RelayImpl(
     private val service: RelayService,
     private val scope: CoroutineScope,
 ) : Relay {
+
     private val tag = "relay-$url"
     private val logger get() = Timber.tag(tag)
 

--- a/nostr/src/main/kotlin/social/plasma/nostr/relay/message/Filters.kt
+++ b/nostr/src/main/kotlin/social/plasma/nostr/relay/message/Filters.kt
@@ -7,10 +7,10 @@ import kotlin.time.Duration.Companion.hours
 
 data class Filters(
     val since: Instant = Instant.now(),
-    val authors: Set<String> = emptySet(),
-    val kinds: Set<Int> = emptySet(),
+    val authors: Set<String>? = null,
+    val kinds: Set<Int>? = null,
     @Json(name = "#e")
-    val eTags: Set<String> = emptySet(),
+    val eTags: Set<String>? = null,
     val limit: Int? = null,
 ) {
     companion object {
@@ -41,7 +41,7 @@ data class Filters(
         )
 
         fun userMetaData(pubKey: String) = userMetaData(pubKeys = setOf(pubKey))
-        
+
         fun userMetaData(pubKeys: Set<String>) = Filters(
             since = Instant.EPOCH,
             authors = pubKeys,


### PR DESCRIPTION

Having default filters as empty sets breaks on most relays.
Changing to nullables so they get skipped during serialization
