### PR TITLE
Fix #86 - Crash when canceling subscriptions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     implementation(libs.okhttp.core)
     implementation(libs.okhttp.interceptor.logging)
 
+    implementation(libs.rxjava)
     implementation(libs.secp256k1.android)
 
     implementation(libs.scarlet.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ moshi = "1.14.0"
 okhttp = "5.0.0-alpha.11"
 paging = "3.1.1"
 room = "2.5.0"
+rxjava = "2.2.21"
 scarlet = "0.1.12"
 
 [plugins]
@@ -92,6 +93,8 @@ moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "mosh
 
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-interceptor-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+
+rxjava = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava" }
 
 scarlet-core = { module = "com.tinder.scarlet:scarlet", version.ref = "scarlet" }
 scarlet-lifecycle-android = { module = "com.tinder.scarlet:lifecycle-android", version.ref = "scarlet" }

--- a/nostr/build.gradle.kts
+++ b/nostr/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.bmuschko.gradle.docker.internal.services.DockerClientService
-import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
 import com.bmuschko.gradle.docker.tasks.container.*
 import com.bmuschko.gradle.docker.tasks.image.*
 import java.net.ServerSocket
@@ -61,6 +59,7 @@ dependencies {
     implementation(libs.scarlet.streamadapter.rxjava)
 
     implementation(libs.timber)
+    implementation(libs.rxjava)
 
     implementation(libs.secp256k1.jvm)
     implementation(libs.secp256k1.jvm.jni)


### PR DESCRIPTION
We have a transitive dependency on an old version rxjava 2. That version introduced a crash that I've seen sporadically.
This PR adds an explicit dependency on the latest (and last) version of rxjava 2